### PR TITLE
Use flowCore functions for fcs file QC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: briDiscovr
 Type: Package
 Title: Distribution analysis across clusters of a parent population overlaid with a rare subpopulation
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(
   person("Mario", "Rosasco", email = "mrosasco@benaroyaresearch.org", role = c("aut", "cre")),
+  person("Matt", "Dufort", email = "mdufort@benaroyaresearch.org", role = c("aut", "cre")),
   person("Virginia", "Muir", role = c("ctb")))
 URL: https://github.com/BenaroyaResearch/briDiscovr
 Description: A package designed to facilitate the metaclustering analysis described in Wiedeman et al., 
@@ -13,7 +14,7 @@ Description: A package designed to facilitate the metaclustering analysis descri
 License: file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2
 LinkingTo: 
     Rcpp
 biocViews:

--- a/man/checkForFcsByteOffsetIssue.Rd
+++ b/man/checkForFcsByteOffsetIssue.Rd
@@ -13,12 +13,16 @@ checkForFcsByteOffsetIssue(fcsFile)
 Boolean: TRUE if there's an offset issue detected, FALSE otherwise
 }
 \description{
-Opens an .fcs file in binary mode and reads the 2 values of
-the byte offset from the text header. These should agree with one another as
-a check for file data integrity, but in practice the values are often off
-by one. This seems to be related to exporting rare gated populations from
-flowJo, and can often be corrected by re-gating and re-exporting.
+Uses flowCore functions to check the 2 values of the byte offset from the
+text header. These should agree with one another as a check for file data
+integrity, but in practice the values are often off by one. This seems to
+be related to exporting rare gated populations from flowJo, and can often
+be corrected by re-gating and re-exporting. This function previously used
+custom code that threw an error when one set of values were 0s; the
+flowCore functions have better handling for this case.
 }
 \author{
 Mario G Rosasco, \email{mrosasco@benaroyaresearch.org}
+
+Matthew J Dufort, \email{mdufort@benaroyaresearch.org}
 }

--- a/man/getFcsNEvents.Rd
+++ b/man/getFcsNEvents.Rd
@@ -17,8 +17,12 @@ Many clustering algorithms cannot handle data objects with no events, so this
 utility is provided as a way to quickly check the number of events in a file.
 The number of events is parsed from the text header using low-level file
 I/O, so counting the events in very large .fcs files will not take
-longer than smaller files.
+longer than smaller files. It was modified in Feb 2022 to use flowCore
+functions that read the data location from the header tags if the values are
+missing from the initial header string.
 }
 \author{
 Mario G Rosasco, \email{mrosasco@benaroyaresearch.org}
+
+Matthew J Dufort, \email{mdufort@benaroyaresearch.org}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // jaccard_coeff
 NumericMatrix jaccard_coeff(NumericMatrix idx);
 RcppExport SEXP _briDiscovr_jaccard_coeff(SEXP idxSEXP) {


### PR DESCRIPTION
Addresses issue https://github.com/BenaroyaResearch/briDiscovr/issues/9. Changes include updates to `checkForFcsByteOffsetIssue`, `getFcsNEvents`, and `setupDiscovrExperiment`. These changes have been tested, but not extensively, as I do not have any positive control cases for the byte offset issue.